### PR TITLE
chore: pin Node.js engines range to >=24.19.0 <25

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
 
       - name: Install NPM version specified in package.json

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ npm test
 
 ## Node & NPM
 
-This project requires Node.js `>=20.0.0` and npm `>=12.0.2 <13` (enforced via
-`check-node-version` on `npm install` and `npm ci`).
+This project requires Node.js `>=24.19.0 <25` and npm `>=12.0.2 <13` (enforced
+via `check-node-version` on `npm install` and `npm ci`).
 
 The check is skipped during `npm publish` and `npm pack`, because
 `semantic-release` bundles its own npm (`@semantic-release/npm` depends on

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "Nordic Semiconductor ASA | nordicsemi.no",
   "license": "BSD-3-Clause",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=24.19.0 <25",
     "npm": ">=12.0.2 <13"
   },
   "scripts": {


### PR DESCRIPTION
This repo already had the npm v12 toolchain guard in place (`check-node-version`, `engines.npm`, the `install-npm` composite action, and the semantic-release-aware `prepare` guard). Only `engines.node` and CI's `setup-node` were still pinned to the old `>=20.0.0` / `22.x`.

This bumps the Node.js requirement to `>=24.19.0 <25`, matching the npm range's style, and updates:
- `package.json` `engines.node`
- `.github/workflows/build-and-publish.yaml` `setup-node` `node-version`
- README's Node & NPM section

The check is skipped during `npm publish` and `npm pack`, because `semantic-release` (invoked via `npx semantic-release` in CI) bundles its own npm and runs the publish with that version rather than the one installed in CI — this guard was already correctly wired and is unchanged.